### PR TITLE
allow the user to specify reference IQR values

### DIFF
--- a/R/MEM_function.R
+++ b/R/MEM_function.R
@@ -1,4 +1,4 @@
-MEM <- function(exp_data, transform=FALSE, cofactor=1, choose.markers=FALSE,markers="all",choose.ref=FALSE,zero.ref=FALSE,rename.markers=FALSE,new.marker.names="none",file.is.clust=FALSE,add.fileID=FALSE,IQR.thresh=NULL,output.prescaled.MEM=FALSE,scale.matrix = "linear",scale.factor = 0)
+MEM <- function(exp_data, transform=FALSE, cofactor=1, choose.markers=FALSE,markers="all",choose.ref=FALSE,zero.ref=FALSE,rename.markers=FALSE,new.marker.names="none",file.is.clust=FALSE,add.fileID=FALSE,IQR.thresh=NULL,output.prescaled.MEM=FALSE,scale.matrix = "linear",scale.factor = 0, input.ref='')
 {
     #determine if the input contains filenames for files that have cluster-specific data with no cluster ID column
     if (file.is.clust == TRUE) {file_order <- exp_data}else {file_order <- 0}
@@ -137,6 +137,15 @@ MEM <- function(exp_data, transform=FALSE, cofactor=1, choose.markers=FALSE,mark
             IQRref[i,] <- apply(subset(exp_data,cluster!=pop),2,FUN=IQR,na.rm=TRUE)
             idx <- which(exp_data[,"cluster"] != pop)
         }
+    }
+    #check if user supplied refernce IQR values to use
+    if (input.ref[1] != ''){
+      #check that list is the same length as number of channels (excluding the cluster column)
+      if (length(input.ref)!=ncol(exp_data)){
+        warning("Number of input reference IQRs does not match the number of channels. 
+                Make sure you included a 0 at the end for the cluster column.",call.=FALSE)
+      }
+      IQRref <- t(as.matrix(input.ref)) #overwrite IQRref with input values
     }
 
     # Set and apply IQR threshold

--- a/R/MEM_function.R
+++ b/R/MEM_function.R
@@ -78,7 +78,7 @@ MEM <- function(exp_data, transform=FALSE, cofactor=1, choose.markers=FALSE,mark
     # Rename markers
     if(rename.markers==TRUE){ #user will specify new marker names via the console
         new_marker_names <- rename_markers(exp_data,marker_names)
-    }else if(rename.markers==FALSE && new.marker.names=="none"){ #user does not want to rename the markers
+    }else if(rename.markers==FALSE && new.marker.names[1]=="none"){ #user does not want to rename the markers
         new_marker_names <- marker_names
     }else{ #user supplied new marker names in a comma-separated list
         user_input_names <- new.marker.names


### PR DESCRIPTION
I created a new parameter (input.ref) that would allow the user to supply custom IQR reference values to use in the MEM calculation (recommended when performing MEM on a single cluster or on very few cells). 

I also edited line 81 to avoid the "Warning: 'length(x) =  #>1' in coercion to 'logical(1)'" that I get with every MEM run.