### PR TITLE
add input.IQR.ref parameter

### DIFF
--- a/R/MEM_function.R
+++ b/R/MEM_function.R
@@ -254,7 +254,7 @@ MEM <- function(exp_data, transform=FALSE, cofactor=1, choose.markers=FALSE,mark
     object_list_labeled[[6]] <- file_order
 
     # List all matrices for export
-    all_values <- list("MAGpop" = object_list_labeled[1],"MAGref"=object_list_labeled[2],"IQRpop"=object_list_labeled[3],"IQRref"=object_list_labeled[4],"MEM_matrix"=object_list_labeled[5], "File Order" = object_list_labeled[6], "prescaled_MEM_matrix"=object_list_labeled[7]
+    all_values <- list("MAGpop" = object_list_labeled[1],"MAGref"=object_list_labeled[2],"IQRpop"=object_list_labeled[3],"IQRref"=object_list_labeled[4],"MEM_matrix"=object_list_labeled[5], "File Order" = object_list_labeled[6], "prescaled_MEM_matrix"=object_list_labeled[7])
     
     #export pre-scaled MEM values
     if(output.prescaled.MEM == TRUE){

--- a/R/MEM_function.R
+++ b/R/MEM_function.R
@@ -1,4 +1,4 @@
-MEM <- function(exp_data, transform=FALSE, cofactor=1, choose.markers=FALSE,markers="all",choose.ref=FALSE,zero.ref=FALSE,rename.markers=FALSE,new.marker.names="none",file.is.clust=FALSE,add.fileID=FALSE,IQR.thresh=NULL,output.prescaled.MEM=FALSE,scale.matrix = "linear",scale.factor = 0)
+MEM <- function(exp_data, transform=FALSE, cofactor=1, choose.markers=FALSE,markers="all",choose.ref=FALSE,zero.ref=FALSE,rename.markers=FALSE,new.marker.names="none",file.is.clust=FALSE,add.fileID=FALSE,IQR.thresh=NULL,output.prescaled.MEM=FALSE,scale.matrix = "linear",scale.factor = 0, input.ref='')
 {
     #determine if the input contains filenames for files that have cluster-specific data with no cluster ID column
     if (file.is.clust == TRUE) {file_order <- exp_data}else {file_order <- 0}
@@ -137,6 +137,15 @@ MEM <- function(exp_data, transform=FALSE, cofactor=1, choose.markers=FALSE,mark
             IQRref[i,] <- apply(subset(exp_data,cluster!=pop),2,FUN=IQR,na.rm=TRUE)
             idx <- which(exp_data[,"cluster"] != pop)
         }
+    }
+    #check if user supplied refernce IQR values to use
+    if (input.ref[1] != ''){
+      #check that list is the same length as number of channels (excluding the cluster column)
+      if (length(input.ref)!=ncol(exp_data)){
+        warning("Number of input reference IQRs does not match the number of channels. 
+                Make sure you included a 0 at the end for the cluster column.",call.=FALSE)
+      }
+      IQRref <- t(as.matrix(input.ref)) #overwrite IQRref with input values
     }
 
     # Set and apply IQR threshold

--- a/R/MEM_function.R
+++ b/R/MEM_function.R
@@ -240,18 +240,21 @@ MEM <- function(exp_data, transform=FALSE, cofactor=1, choose.markers=FALSE,mark
                                          t(as.matrix(MAGref[,1:length(marker_names)-1])),
                                          t(as.matrix(IQRpop[,1:length(marker_names)-1])),
                                          t(as.matrix(IQRref[,1:length(marker_names)-1])),
-                                         t(as.matrix(MEM_matrix[,1:length(marker_names)-1]))),rename_table)
+                                         t(as.matrix(MEM_matrix[,1:length(marker_names)-1])),
+                                         t(as.matrix(prescaled_MEM_matrix[,1:length(marker_names)-1]))), rename_table)
     }else{
       object_list_labeled <- lapply(list(as.matrix(MAGpop[,1:length(marker_names)-1]),
                                          as.matrix(MAGref[,1:length(marker_names)-1]),
                                          as.matrix(IQRpop[,1:length(marker_names)-1]),
                                          as.matrix(IQRref[,1:length(marker_names)-1]),
-                                         as.matrix(MEM_matrix[,1:length(marker_names)-1])),rename_table)
+                                         as.matrix(MEM_matrix[,1:length(marker_names)-1]), 
+                                         as.matrix(prescaled_MEM_matrix[,1:length(marker_names)-1])), rename_table)
     }
+    object_list_labeled[[7]] <- object_list_labeled[[6]] #move prescaled MEM matrix to element 7
     object_list_labeled[[6]] <- file_order
 
     # List all matrices for export
-    all_values <- list("MAGpop" = object_list_labeled[1],"MAGref"=object_list_labeled[2],"IQRpop"=object_list_labeled[3],"IQRref"=object_list_labeled[4],"MEM_matrix"=object_list_labeled[5],"File Order" = object_list_labeled[6])
+    all_values <- list("MAGpop" = object_list_labeled[1],"MAGref"=object_list_labeled[2],"IQRpop"=object_list_labeled[3],"IQRref"=object_list_labeled[4],"MEM_matrix"=object_list_labeled[5], "File Order" = object_list_labeled[6], "prescaled_MEM_matrix"=object_list_labeled[7]
     
     #export pre-scaled MEM values
     if(output.prescaled.MEM == TRUE){

--- a/R/MEM_function.R
+++ b/R/MEM_function.R
@@ -78,7 +78,7 @@ MEM <- function(exp_data, transform=FALSE, cofactor=1, choose.markers=FALSE,mark
     # Rename markers
     if(rename.markers==TRUE){ #user will specify new marker names via the console
         new_marker_names <- rename_markers(exp_data,marker_names)
-    }else if(rename.markers==FALSE && new.marker.names=="none"){ #user does not want to rename the markers
+    }else if(rename.markers==FALSE && new.marker.names[1]=="none"){ #user does not want to rename the markers
         new_marker_names <- marker_names
     }else{ #user supplied new marker names in a comma-separated list
         user_input_names <- new.marker.names


### PR DESCRIPTION
Added the input.IQR.ref parameter that allows the user to specify a custom IQR reference value to use in zero.ref MEM. This parameter should be used when performing MEM on a single cluster or on very few cells in which the calculated IQR reference value may not be representative of a typical IQR value in a larger dataset containing multiple distinct cell clusters.

Also edited line 81 to avoid the "Warning: 'length(x) = #>1' in coercion to 'logical(1)'" that I get with every MEM run, and edited lines 105 and 107 to avoid a replacement length error that was occurring in referenced MEM that I missed in previous tests.